### PR TITLE
feat: subscription support via IPC WebSocket

### DIFF
--- a/hugr/__init__.py
+++ b/hugr/__init__.py
@@ -12,6 +12,7 @@ from .stream import (
     HugrStreamConnection,
     HugrStreamingClient,
     HugrStream,
+    HugrSubscription,
     connect_stream,
     new_stream_connection,
 )
@@ -27,6 +28,7 @@ __all__ = [
     "HugrStreamConnection",
     "HugrStreamingClient",
     "HugrStream",
+    "HugrSubscription",
     "connect_stream",
     "new_stream_connection",
 ]

--- a/hugr/__init__.py
+++ b/hugr/__init__.py
@@ -13,6 +13,7 @@ from .stream import (
     HugrStreamingClient,
     HugrStream,
     HugrSubscription,
+    SubscriptionEvent,
     connect_stream,
     new_stream_connection,
 )
@@ -29,6 +30,7 @@ __all__ = [
     "HugrStreamingClient",
     "HugrStream",
     "HugrSubscription",
+    "SubscriptionEvent",
     "connect_stream",
     "new_stream_connection",
 ]

--- a/hugr/stream.py
+++ b/hugr/stream.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import ssl
+import uuid
 import websockets
 import pandas as pd
 import pyarrow as pa
@@ -308,6 +309,78 @@ class HugrStreamingClient:
         finally:
             self._query_active = False
 
+    # --- Subscriptions ---
+
+    async def subscribe(self, query: str, variables: dict = None) -> 'HugrSubscription':
+        """Subscribe to a GraphQL subscription query.
+        Returns HugrSubscription for async iteration over events."""
+        if not self._connected:
+            await self.connect()
+
+        sub_id = str(uuid.uuid4())
+        sub = HugrSubscription(sub_id, self)
+
+        if not hasattr(self, '_subscriptions'):
+            self._subscriptions: Dict[str, 'HugrSubscription'] = {}
+            self._router_task = asyncio.create_task(self._subscription_router())
+        self._subscriptions[sub_id] = sub
+
+        await self.websocket.send(json.dumps({
+            "type": "subscribe",
+            "subscription_id": sub_id,
+            "query": query,
+            "variables": variables or {},
+        }))
+        return sub
+
+    async def _subscription_router(self):
+        """Routes incoming WebSocket messages to subscriptions by Arrow schema metadata."""
+        try:
+            while self._connected:
+                try:
+                    message = await asyncio.wait_for(self.websocket.recv(), timeout=60)
+                except asyncio.TimeoutError:
+                    continue
+                except Exception:
+                    break
+
+                if isinstance(message, bytes):
+                    try:
+                        reader = pa.ipc.open_stream(message)
+                        meta = reader.schema.metadata or {}
+                        sub_id = meta.get(b"subscription_id", b"").decode()
+                        path = meta.get(b"path", b"").decode()
+                        if sub_id and sub_id in self._subscriptions:
+                            pipe = self._subscriptions[sub_id]._get_or_create_pipe(path)
+                            for batch in reader.read_all().to_batches():
+                                pipe._push(batch)
+                    except Exception as e:
+                        logger.warning(f"Error parsing Arrow batch: {e}")
+                else:
+                    try:
+                        data = json.loads(message)
+                    except json.JSONDecodeError:
+                        continue
+                    msg_type = data.get("type", "")
+                    sub_id = data.get("subscription_id", "")
+                    if msg_type == "subscription_complete":
+                        if sub_id in self._subscriptions:
+                            self._subscriptions.pop(sub_id)._complete()
+                    elif msg_type == "subscription_error":
+                        if sub_id in self._subscriptions:
+                            self._subscriptions.pop(sub_id)._complete(error=data.get("error"))
+                    elif msg_type == "part_complete":
+                        pass  # marker between ticks, pipes stay open
+                    elif msg_type == "complete":
+                        self._query_active = False
+        except Exception as e:
+            logger.warning(f"Subscription router error: {e}")
+        finally:
+            for sub in getattr(self, '_subscriptions', {}).values():
+                sub._complete(error="connection closed")
+            if hasattr(self, '_subscriptions'):
+                self._subscriptions.clear()
+
     async def __aenter__(self):
         await self.connect()
         return self
@@ -364,6 +437,11 @@ class HugrStreamConnection(HugrClient):
         client = self._get_streaming_client()
         return await client.stream_data_object(data_object, fields, variables)
 
+    async def subscribe(self, query: str, variables: dict = None) -> 'HugrSubscription':
+        """Subscribe via streaming client (auto-connects)."""
+        client = self._get_streaming_client()
+        return await client.subscribe(query, variables)
+
     async def streaming_context(self):
         """Get streaming client for manual connection management"""
         return self._get_streaming_client()
@@ -376,7 +454,7 @@ class SubscriptionEvent:
     def __init__(self, path: str):
         self.path = path
         self._queue: asyncio.Queue = asyncio.Queue()
-        self._done = False
+        self._closed = False
 
     async def chunks(self) -> AsyncGenerator[pa.RecordBatch, None]:
         """Yield Arrow RecordBatches as they arrive across all ticks."""
@@ -404,8 +482,8 @@ class SubscriptionEvent:
         self._queue.put_nowait(batch)
 
     def _close(self):
-        if not self._done:
-            self._done = True
+        if not self._closed:
+            self._closed = True
             self._queue.put_nowait(None)
 
 
@@ -457,100 +535,6 @@ class HugrSubscription:
         for pipe in self._pipes.values():
             pipe._close()
         self._events.put_nowait(None)
-
-
-# --- Subscription support on HugrStreamingClient ---
-
-async def _subscribe(self: HugrStreamingClient, query: str, variables: dict = None) -> HugrSubscription:
-    """Subscribe to a GraphQL subscription query."""
-    if not self._connected:
-        await self.connect()
-
-    import uuid
-    sub_id = str(uuid.uuid4())
-    sub = HugrSubscription(sub_id, self)
-
-    if not hasattr(self, '_subscriptions'):
-        self._subscriptions = {}
-        self._router_task = asyncio.create_task(_subscription_router(self))
-    self._subscriptions[sub_id] = sub
-
-    await self.websocket.send(json.dumps({
-        "type": "subscribe",
-        "subscription_id": sub_id,
-        "query": query,
-        "variables": variables or {},
-    }))
-
-    return sub
-
-
-async def _subscription_router(client: HugrStreamingClient):
-    """Routes incoming WebSocket messages to subscriptions by Arrow schema metadata."""
-    try:
-        while client._connected:
-            try:
-                message = await asyncio.wait_for(client.websocket.recv(), timeout=60)
-            except asyncio.TimeoutError:
-                continue
-            except Exception:
-                break
-
-            if isinstance(message, bytes):
-                try:
-                    reader = pa.ipc.open_stream(message)
-                    schema = reader.schema
-                    meta = schema.metadata or {}
-                    sub_id = meta.get(b"subscription_id", b"").decode()
-                    path = meta.get(b"path", b"").decode()
-
-                    if sub_id and sub_id in client._subscriptions:
-                        sub = client._subscriptions[sub_id]
-                        pipe = sub._get_or_create_pipe(path)
-                        for batch in reader.read_all().to_batches():
-                            pipe._push(batch)
-                except Exception as e:
-                    logger.warning(f"Error parsing Arrow batch: {e}")
-            else:
-                try:
-                    data = json.loads(message)
-                except json.JSONDecodeError:
-                    continue
-
-                msg_type = data.get("type", "")
-                sub_id = data.get("subscription_id", "")
-
-                if msg_type == "subscription_complete":
-                    if sub_id in client._subscriptions:
-                        client._subscriptions[sub_id]._complete()
-                        del client._subscriptions[sub_id]
-                elif msg_type == "subscription_error":
-                    if sub_id in client._subscriptions:
-                        client._subscriptions[sub_id]._complete(error=data.get("error"))
-                        del client._subscriptions[sub_id]
-                elif msg_type == "part_complete":
-                    pass  # marker between ticks, pipes stay open
-                elif msg_type == "complete":
-                    if hasattr(client, '_query_active'):
-                        client._query_active = False
-    except Exception as e:
-        logger.warning(f"Subscription router error: {e}")
-    finally:
-        subs = getattr(client, '_subscriptions', {})
-        for sub in subs.values():
-            sub._complete(error="connection closed")
-        subs.clear()
-
-
-HugrStreamingClient.subscribe = _subscribe
-
-
-async def _stream_conn_subscribe(self: HugrStreamConnection, query: str, variables: dict = None) -> HugrSubscription:
-    """Subscribe via streaming client."""
-    client = self._get_streaming_client()
-    return await client.subscribe(query, variables)
-
-HugrStreamConnection.subscribe = _stream_conn_subscribe
 
 
 # Main interface

--- a/hugr/stream.py
+++ b/hugr/stream.py
@@ -380,7 +380,7 @@ class SubscriptionEvent:
 
     async def chunks(self) -> AsyncGenerator[pa.RecordBatch, None]:
         """Yield Arrow RecordBatches as they arrive across all ticks."""
-        while not self._done:
+        while True:
             item = await self._queue.get()
             if item is None:
                 break
@@ -423,7 +423,7 @@ class HugrSubscription:
 
     async def events(self) -> AsyncGenerator['SubscriptionEvent', None]:
         """Yield SubscriptionEvents (one per unique path)."""
-        while not self._done:
+        while True:
             item = await self._events.get()
             if item is None:
                 break

--- a/hugr/stream.py
+++ b/hugr/stream.py
@@ -369,19 +369,17 @@ class HugrStreamConnection(HugrClient):
         return self._get_streaming_client()
 
 
-class HugrSubscription:
-    """A single subscription handle with async iteration over Arrow batches."""
+class SubscriptionEvent:
+    """A single event from a subscription — one path with an async batch iterator.
+    Batches flow through all ticks. chunks() ends on subscription_complete."""
 
-    def __init__(self, subscription_id: str, client: 'HugrStreamingClient'):
-        self.id = subscription_id
-        self._client = client
+    def __init__(self, path: str):
+        self.path = path
         self._queue: asyncio.Queue = asyncio.Queue()
         self._done = False
-        self._error = None
-        self._current_path = ""
 
     async def chunks(self) -> AsyncGenerator[pa.RecordBatch, None]:
-        """Yield Arrow RecordBatches as they arrive."""
+        """Yield Arrow RecordBatches as they arrive across all ticks."""
         while not self._done:
             item = await self._queue.get()
             if item is None:
@@ -402,6 +400,35 @@ class HugrSubscription:
             return pd.DataFrame()
         return pa.Table.from_batches(batches).to_pandas()
 
+    def _push(self, batch: pa.RecordBatch):
+        self._queue.put_nowait(batch)
+
+    def _close(self):
+        if not self._done:
+            self._done = True
+            self._queue.put_nowait(None)
+
+
+class HugrSubscription:
+    """A subscription handle that yields SubscriptionEvents (one per unique path).
+    Each event has a reader that spans all ticks until subscription completes."""
+
+    def __init__(self, subscription_id: str, client: 'HugrStreamingClient'):
+        self.id = subscription_id
+        self._client = client
+        self._events: asyncio.Queue = asyncio.Queue()
+        self._pipes: Dict[str, SubscriptionEvent] = {}
+        self._done = False
+        self._error = None
+
+    async def events(self) -> AsyncGenerator['SubscriptionEvent', None]:
+        """Yield SubscriptionEvents (one per unique path)."""
+        while not self._done:
+            item = await self._events.get()
+            if item is None:
+                break
+            yield item
+
     async def cancel(self):
         """Cancel the subscription."""
         if self._client and self._client.websocket:
@@ -412,24 +439,30 @@ class HugrSubscription:
                 }))
             except Exception:
                 pass
-        self._done = True
-        await self._queue.put(None)
+        self._complete()
 
-    def _push_batch(self, batch: pa.RecordBatch):
-        """Push a batch to the queue (called by message router)."""
-        self._queue.put_nowait(batch)
+    def _get_or_create_pipe(self, path: str) -> SubscriptionEvent:
+        if path in self._pipes:
+            return self._pipes[path]
+        event = SubscriptionEvent(path)
+        self._pipes[path] = event
+        self._events.put_nowait(event)
+        return event
 
     def _complete(self, error: str = None):
-        """Mark subscription as complete."""
+        if self._done:
+            return
         self._done = True
         self._error = error
-        self._queue.put_nowait(None)
+        for pipe in self._pipes.values():
+            pipe._close()
+        self._events.put_nowait(None)
 
 
 # --- Subscription support on HugrStreamingClient ---
 
 async def _subscribe(self: HugrStreamingClient, query: str, variables: dict = None) -> HugrSubscription:
-    """Subscribe to a GraphQL subscription query. Returns HugrSubscription for async iteration."""
+    """Subscribe to a GraphQL subscription query."""
     if not self._connected:
         await self.connect()
 
@@ -437,14 +470,11 @@ async def _subscribe(self: HugrStreamingClient, query: str, variables: dict = No
     sub_id = str(uuid.uuid4())
     sub = HugrSubscription(sub_id, self)
 
-    # Register subscription
     if not hasattr(self, '_subscriptions'):
         self._subscriptions = {}
-        # Start message router on first subscribe
         self._router_task = asyncio.create_task(_subscription_router(self))
     self._subscriptions[sub_id] = sub
 
-    # Send subscribe message
     await self.websocket.send(json.dumps({
         "type": "subscribe",
         "subscription_id": sub_id,
@@ -456,8 +486,7 @@ async def _subscribe(self: HugrStreamingClient, query: str, variables: dict = No
 
 
 async def _subscription_router(client: HugrStreamingClient):
-    """Background task that routes incoming WebSocket messages to subscriptions."""
-    pending_sub_id = None
+    """Routes incoming WebSocket messages to subscriptions by Arrow schema metadata."""
     try:
         while client._connected:
             try:
@@ -468,17 +497,21 @@ async def _subscription_router(client: HugrStreamingClient):
                 break
 
             if isinstance(message, bytes):
-                # Arrow IPC binary frame → route to pending subscription
-                if pending_sub_id and pending_sub_id in client._subscriptions:
-                    try:
-                        reader = pa.ipc.open_stream(message)
+                try:
+                    reader = pa.ipc.open_stream(message)
+                    schema = reader.schema
+                    meta = schema.metadata or {}
+                    sub_id = meta.get(b"subscription_id", b"").decode()
+                    path = meta.get(b"path", b"").decode()
+
+                    if sub_id and sub_id in client._subscriptions:
+                        sub = client._subscriptions[sub_id]
+                        pipe = sub._get_or_create_pipe(path)
                         for batch in reader.read_all().to_batches():
-                            client._subscriptions[pending_sub_id]._push_batch(batch)
-                    except Exception as e:
-                        logger.warning(f"Error parsing Arrow batch: {e}")
-                pending_sub_id = None
+                            pipe._push(batch)
+                except Exception as e:
+                    logger.warning(f"Error parsing Arrow batch: {e}")
             else:
-                # Text frame — control message
                 try:
                     data = json.loads(message)
                 except json.JSONDecodeError:
@@ -487,12 +520,7 @@ async def _subscription_router(client: HugrStreamingClient):
                 msg_type = data.get("type", "")
                 sub_id = data.get("subscription_id", "")
 
-                if msg_type == "subscription_data":
-                    pending_sub_id = sub_id
-                elif msg_type == "part_start":
-                    if sub_id in client._subscriptions:
-                        client._subscriptions[sub_id]._current_path = data.get("path", "")
-                elif msg_type == "subscription_complete":
+                if msg_type == "subscription_complete":
                     if sub_id in client._subscriptions:
                         client._subscriptions[sub_id]._complete()
                         del client._subscriptions[sub_id]
@@ -500,25 +528,23 @@ async def _subscription_router(client: HugrStreamingClient):
                     if sub_id in client._subscriptions:
                         client._subscriptions[sub_id]._complete(error=data.get("error"))
                         del client._subscriptions[sub_id]
+                elif msg_type == "part_complete":
+                    pass  # marker between ticks, pipes stay open
                 elif msg_type == "complete":
-                    # Regular query complete — pass through for non-subscription handling
                     if hasattr(client, '_query_active'):
                         client._query_active = False
     except Exception as e:
         logger.warning(f"Subscription router error: {e}")
     finally:
-        # Complete all remaining subscriptions
         subs = getattr(client, '_subscriptions', {})
         for sub in subs.values():
             sub._complete(error="connection closed")
         subs.clear()
 
 
-# Monkey-patch subscribe onto HugrStreamingClient
 HugrStreamingClient.subscribe = _subscribe
 
 
-# Also add to HugrStreamConnection
 async def _stream_conn_subscribe(self: HugrStreamConnection, query: str, variables: dict = None) -> HugrSubscription:
     """Subscribe via streaming client."""
     client = self._get_streaming_client()

--- a/hugr/stream.py
+++ b/hugr/stream.py
@@ -369,6 +369,164 @@ class HugrStreamConnection(HugrClient):
         return self._get_streaming_client()
 
 
+class HugrSubscription:
+    """A single subscription handle with async iteration over Arrow batches."""
+
+    def __init__(self, subscription_id: str, client: 'HugrStreamingClient'):
+        self.id = subscription_id
+        self._client = client
+        self._queue: asyncio.Queue = asyncio.Queue()
+        self._done = False
+        self._error = None
+        self._current_path = ""
+
+    async def chunks(self) -> AsyncGenerator[pa.RecordBatch, None]:
+        """Yield Arrow RecordBatches as they arrive."""
+        while not self._done:
+            item = await self._queue.get()
+            if item is None:
+                break
+            yield item
+
+    async def rows(self) -> AsyncGenerator[Dict[str, Any], None]:
+        """Yield rows as dicts."""
+        async for batch in self.chunks():
+            schema = batch.schema
+            for i in range(batch.num_rows):
+                yield {schema.field(j).name: batch.column(j)[i].as_py() for j in range(batch.num_columns)}
+
+    async def to_pandas(self) -> pd.DataFrame:
+        """Collect all batches into a pandas DataFrame."""
+        batches = [b async for b in self.chunks()]
+        if not batches:
+            return pd.DataFrame()
+        return pa.Table.from_batches(batches).to_pandas()
+
+    async def cancel(self):
+        """Cancel the subscription."""
+        if self._client and self._client.websocket:
+            try:
+                await self._client.websocket.send(json.dumps({
+                    "type": "unsubscribe",
+                    "subscription_id": self.id,
+                }))
+            except Exception:
+                pass
+        self._done = True
+        await self._queue.put(None)
+
+    def _push_batch(self, batch: pa.RecordBatch):
+        """Push a batch to the queue (called by message router)."""
+        self._queue.put_nowait(batch)
+
+    def _complete(self, error: str = None):
+        """Mark subscription as complete."""
+        self._done = True
+        self._error = error
+        self._queue.put_nowait(None)
+
+
+# --- Subscription support on HugrStreamingClient ---
+
+async def _subscribe(self: HugrStreamingClient, query: str, variables: dict = None) -> HugrSubscription:
+    """Subscribe to a GraphQL subscription query. Returns HugrSubscription for async iteration."""
+    if not self._connected:
+        await self.connect()
+
+    import uuid
+    sub_id = str(uuid.uuid4())
+    sub = HugrSubscription(sub_id, self)
+
+    # Register subscription
+    if not hasattr(self, '_subscriptions'):
+        self._subscriptions = {}
+        # Start message router on first subscribe
+        self._router_task = asyncio.create_task(_subscription_router(self))
+    self._subscriptions[sub_id] = sub
+
+    # Send subscribe message
+    await self.websocket.send(json.dumps({
+        "type": "subscribe",
+        "subscription_id": sub_id,
+        "query": query,
+        "variables": variables or {},
+    }))
+
+    return sub
+
+
+async def _subscription_router(client: HugrStreamingClient):
+    """Background task that routes incoming WebSocket messages to subscriptions."""
+    pending_sub_id = None
+    try:
+        while client._connected:
+            try:
+                message = await asyncio.wait_for(client.websocket.recv(), timeout=60)
+            except asyncio.TimeoutError:
+                continue
+            except Exception:
+                break
+
+            if isinstance(message, bytes):
+                # Arrow IPC binary frame → route to pending subscription
+                if pending_sub_id and pending_sub_id in client._subscriptions:
+                    try:
+                        reader = pa.ipc.open_stream(message)
+                        for batch in reader.read_all().to_batches():
+                            client._subscriptions[pending_sub_id]._push_batch(batch)
+                    except Exception as e:
+                        logger.warning(f"Error parsing Arrow batch: {e}")
+                pending_sub_id = None
+            else:
+                # Text frame — control message
+                try:
+                    data = json.loads(message)
+                except json.JSONDecodeError:
+                    continue
+
+                msg_type = data.get("type", "")
+                sub_id = data.get("subscription_id", "")
+
+                if msg_type == "subscription_data":
+                    pending_sub_id = sub_id
+                elif msg_type == "part_start":
+                    if sub_id in client._subscriptions:
+                        client._subscriptions[sub_id]._current_path = data.get("path", "")
+                elif msg_type == "subscription_complete":
+                    if sub_id in client._subscriptions:
+                        client._subscriptions[sub_id]._complete()
+                        del client._subscriptions[sub_id]
+                elif msg_type == "subscription_error":
+                    if sub_id in client._subscriptions:
+                        client._subscriptions[sub_id]._complete(error=data.get("error"))
+                        del client._subscriptions[sub_id]
+                elif msg_type == "complete":
+                    # Regular query complete — pass through for non-subscription handling
+                    if hasattr(client, '_query_active'):
+                        client._query_active = False
+    except Exception as e:
+        logger.warning(f"Subscription router error: {e}")
+    finally:
+        # Complete all remaining subscriptions
+        subs = getattr(client, '_subscriptions', {})
+        for sub in subs.values():
+            sub._complete(error="connection closed")
+        subs.clear()
+
+
+# Monkey-patch subscribe onto HugrStreamingClient
+HugrStreamingClient.subscribe = _subscribe
+
+
+# Also add to HugrStreamConnection
+async def _stream_conn_subscribe(self: HugrStreamConnection, query: str, variables: dict = None) -> HugrSubscription:
+    """Subscribe via streaming client."""
+    client = self._get_streaming_client()
+    return await client.subscribe(query, variables)
+
+HugrStreamConnection.subscribe = _stream_conn_subscribe
+
+
 # Main interface
 
 

--- a/test_subscription.py
+++ b/test_subscription.py
@@ -1,0 +1,170 @@
+"""
+Test subscription support against a running hugr server.
+Usage: python test_subscription.py [URL]
+Default URL: http://localhost:15004/ipc
+"""
+import asyncio
+import json
+import sys
+from hugr import connect_stream
+
+
+async def test_query_streaming(url: str):
+    """Test basic query streaming — one event per path."""
+    print("=== Test: Query Streaming ===")
+    client = connect_stream(url)
+
+    sub = await client.subscribe(
+        'subscription { query { core { catalog { types(limit: 3, order_by: [{field: "name", direction: ASC}]) { name kind } } } } }'
+    )
+
+    event_count = 0
+    row_count = 0
+    async for event in sub.events():
+        event_count += 1
+        print(f"  event: path={event.path}")
+        async for row in event.rows():
+            row_count += 1
+            if row_count <= 3:
+                print(f"    row {row_count}: {row}")
+
+    await client.disconnect()
+    assert event_count == 1, f"Expected 1 event (one path), got {event_count}"
+    assert row_count > 0, "Should have rows"
+    print(f"  Result: {event_count} events, {row_count} rows")
+    print("  PASS\n")
+
+
+async def test_periodic_polling(url: str):
+    """Test periodic — one event per path, batches from all ticks."""
+    print("=== Test: Periodic Polling (interval=500ms, count=3) ===")
+    client = connect_stream(url)
+
+    sub = await client.subscribe(
+        'subscription { query(interval: "500ms", count: 3) { core { catalog { types(limit: 5, order_by: [{field: "name", direction: ASC}]) { name } } } } }'
+    )
+
+    event_count = 0
+    total_rows = 0
+    async for event in sub.events():
+        event_count += 1
+        async for batch in event.chunks():
+            total_rows += batch.num_rows
+
+    await client.disconnect()
+    assert event_count == 1, f"Expected 1 event (one path across ticks), got {event_count}"
+    assert total_rows == 15, f"Expected 15 rows (3 ticks × 5), got {total_rows}"
+    print(f"  Result: {event_count} events, {total_rows} total rows")
+    print("  PASS\n")
+
+
+async def test_multi_path(url: str):
+    """Test multi-path query — two events (one per path)."""
+    print("=== Test: Multi-Path Query ===")
+    client = connect_stream(url)
+
+    sub = await client.subscribe('''subscription { query {
+        core { catalog {
+            types(limit: 3, order_by: [{field: "name", direction: ASC}]) { name kind }
+            fields(limit: 3, order_by: [{field: "name", direction: ASC}]) { name field_type }
+        } }
+    } }''')
+
+    paths = {}
+    async for event in sub.events():
+        rows = 0
+        async for batch in event.chunks():
+            rows += batch.num_rows
+        paths[event.path] = rows
+        print(f"  path={event.path}: {rows} rows")
+
+    await client.disconnect()
+    assert len(paths) == 2, f"Expected 2 paths, got {len(paths)}"
+    for path, rows in paths.items():
+        assert rows > 0, f"Path {path} should have rows"
+    print(f"  Result: {len(paths)} paths")
+    print("  PASS\n")
+
+
+async def test_two_subscriptions(url: str):
+    """Test two subscriptions on same connection — same data."""
+    print("=== Test: Two Subscriptions Same Data ===")
+    client = connect_stream(url)
+
+    query = '''subscription { query(interval: "500ms", count: 5) {
+        core { catalog {
+            types(limit: 10, order_by: [{field: "name", direction: ASC}]) { name kind }
+        } }
+    } }'''
+
+    sub1 = await client.subscribe(query)
+    sub2 = await client.subscribe(query)
+
+    async def collect(sub):
+        result = {}
+        async for event in sub.events():
+            rows = []
+            async for batch in event.chunks():
+                for i in range(batch.num_rows):
+                    row = {batch.schema.field(j).name: batch.column(j)[i].as_py()
+                           for j in range(batch.num_columns)}
+                    rows.append(json.dumps(row, sort_keys=True))
+            result[event.path] = rows
+        return result
+
+    data1, data2 = await asyncio.gather(collect(sub1), collect(sub2))
+
+    await client.disconnect()
+
+    assert len(data1) > 0, "sub1 should have data"
+    assert len(data2) > 0, "sub2 should have data"
+
+    for path in data1:
+        assert path in data2, f"sub2 missing path {path}"
+        assert len(data1[path]) == len(data2[path]), \
+            f"path {path}: sub1={len(data1[path])} rows, sub2={len(data2[path])} rows"
+        # First row should match (sorted, deterministic)
+        assert data1[path][0] == data2[path][0], \
+            f"path {path}: first row mismatch"
+        print(f"  path={path}: {len(data1[path])} rows match")
+
+    print("  PASS\n")
+
+
+async def test_cancel(url: str):
+    """Test subscription cancellation."""
+    print("=== Test: Cancel ===")
+    client = connect_stream(url)
+
+    sub = await client.subscribe(
+        'subscription { query(interval: "60s") { core { catalog { types(limit: 1) { name } } } } }'
+    )
+
+    # Get first event
+    async for event in sub.events():
+        async for batch in event.chunks():
+            print(f"  first batch: {batch.num_rows} rows")
+            break
+        break
+
+    await sub.cancel()
+    await client.disconnect()
+    print("  Cancelled successfully")
+    print("  PASS\n")
+
+
+async def main():
+    url = sys.argv[1] if len(sys.argv) > 1 else "http://localhost:15004/ipc"
+    print(f"Testing Python subscription client against {url}\n")
+
+    await test_query_streaming(url)
+    await test_periodic_polling(url)
+    await test_multi_path(url)
+    await test_two_subscriptions(url)
+    await test_cancel(url)
+
+    print("All tests passed!")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Add subscription support to the Python hugr-client, matching the Go client architecture.

## Changes

- **`SubscriptionEvent`**: async batch iterator per path, persists across ticks
  - `chunks()` — yield Arrow RecordBatches
  - `rows()` — yield dicts
  - `to_pandas()` — collect to DataFrame
- **`HugrSubscription`**: yields `SubscriptionEvent` per unique path via `events()`
- **Message router**: background task reads WebSocket, routes by Arrow schema metadata (`subscription_id`, `path`)
- **Multiple subscriptions** on same connection via shared router
- `subscribe()` method on `HugrStreamingClient` and `HugrStreamConnection`
- No text frame markers — Arrow metadata routing only

## Usage

```python
client = connect_stream("http://localhost:15004/ipc")
sub = await client.subscribe('''
    subscription { query(interval: "1s", count: 5) {
        core { catalog { types(limit: 10) { name kind } } }
    } }
''')

async for event in sub.events():
    async for row in event.rows():
        print(row)
```

## Test plan

- [x] `python test_subscription.py` — 5 tests (query streaming, periodic, multi-path, two subs, cancel)
- [x] Tested against hugr v0.3.20

🤖 Generated with [Claude Code](https://claude.com/claude-code)