### PR TITLE
fix: surface GraphQL errors from the multipart `errors` part

### DIFF
--- a/hugr/__init__.py
+++ b/hugr/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "new_stream_connection",
 ]
 
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/hugr/client.py
+++ b/hugr/client.py
@@ -511,21 +511,46 @@ def _encode_geojson(val, fmt):
 class HugrIPCResponse:
     _parts: Dict[str, Union[HugrIPCTable, HugrIPCObject]]
     _extensions: Dict[str, HugrIPCObject]
+    _errors: List[Any]
 
     def __init__(self, response: requests.Response):
-        self._parts, self._extensions = self._parse_multipart(response)
+        self._parts, self._extensions, self._errors = self._parse_multipart(response)
+        # Fail fast on an errors-only response (e.g. a GraphQL syntax
+        # error): the server returns just an `errors` part and no data,
+        # so raising here stops the caller mistaking it for an empty
+        # result. A partial response (data + errors) is returned with
+        # `.errors` populated — call `.raise_for_errors()` to surface
+        # those too.
+        if self._errors and not self._parts:
+            raise ValueError(f"GraphQL errors: {self._error_text()}")
 
     def _parse_multipart(self, response: requests.Response):
         data = decoder.MultipartDecoder.from_response(response)
         parts: Dict[str, Union[HugrIPCTable, HugrIPCObject]] = {}
         extensions: Dict[str, HugrIPCObject] = {}
+        errors: List[Any] = []
         for part in data.parts:
             headers = {k.decode(): v.decode() for k, v in part.headers.items()}
             path = headers.get("X-Hugr-Path")
             part_type = headers.get("X-Hugr-Part-Type")
             format = headers.get("X-Hugr-Format")
-            if part_type == "error":
-                raise ValueError(f"Error in part {path}: {part.content.decode()}")
+            if part_type in ("error", "errors"):
+                # The server emits GraphQL errors as a dedicated part with
+                # X-Hugr-Part-Type "errors" (plural — see query-engine
+                # writeErrorsToIPC). Collect rather than raise mid-parse so
+                # a partial-success response keeps its data; __init__ raises
+                # when the response is errors-only.
+                try:
+                    payload = json.loads(part.content)
+                except (ValueError, TypeError):
+                    payload = part.content.decode()
+                # gqlerror.List is a JSON ARRAY — flatten it into the flat
+                # error list; tolerate a bare object / string defensively.
+                if isinstance(payload, list):
+                    errors.extend(payload)
+                else:
+                    errors.append(payload)
+                continue
             if format == "table":
                 if headers.get("X-Hugr-Empty", "false") == "true":
                     parts[path] = HugrIPCTable(path, [], {}, False)
@@ -544,11 +569,31 @@ class HugrIPCResponse:
                 content = json.loads(part.content)
                 extensions[path] = HugrIPCObject(path, content)
 
-        return parts, extensions
+        return parts, extensions, errors
 
     @property
     def parts(self):
         return self._parts
+
+    @property
+    def errors(self) -> List[Any]:
+        """GraphQL errors as a flat list of error objects (the server's
+        `errors` part carries a JSON array). Empty when the query
+        succeeded. An errors-ONLY response raises in __init__; a partial
+        response (data + errors) is returned with this populated."""
+        return self._errors
+
+    def raise_for_errors(self):
+        """Raise ValueError if the response carries ANY GraphQL errors —
+        use after a query to make a partial-success response fail loud."""
+        if self._errors:
+            raise ValueError(f"GraphQL errors: {self._error_text()}")
+
+    def _error_text(self) -> str:
+        try:
+            return json.dumps(self._errors, ensure_ascii=False)
+        except (TypeError, ValueError):
+            return str(self._errors)
 
     def __iter__(self):
         return iter(self._parts.keys())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hugr-client"
-version = "0.3.0"
+version = "0.3.1"
 description = "Python client for Hugr Arrow IPC over multipart/mixed"
 authors = [
     { name = "Hugr-lab", email = "gribanov.vladimir@gmail.com" }

--- a/test_ipc_errors.py
+++ b/test_ipc_errors.py
@@ -1,0 +1,78 @@
+"""Unit tests for HugrIPCResponse error-part handling.
+
+Regression for the silent-drop bug: the server emits GraphQL errors as a
+multipart part with `X-Hugr-Part-Type: errors` (plural, a JSON array);
+the client must surface them, not skip them.
+"""
+from hugr.client import HugrIPCResponse
+
+BOUNDARY = "testboundary"
+
+
+class _FakeResp:
+    def __init__(self, body: bytes, content_type: str):
+        self.content = body
+        self.encoding = "utf-8"
+        self.headers = {"content-type": content_type}
+
+
+def _multipart(*parts: bytes) -> _FakeResp:
+    body = b""
+    for p in parts:
+        body += b"--" + BOUNDARY.encode() + b"\r\n" + p + b"\r\n"
+    body += b"--" + BOUNDARY.encode() + b"--\r\n"
+    return _FakeResp(body, f"multipart/mixed; boundary={BOUNDARY}")
+
+
+ERRORS_PART = (
+    b"Content-Type: application/json\r\n"
+    b"X-Hugr-Part-Type: errors\r\n"
+    b"X-Hugr-Format: object\r\n"
+    b"\r\n"
+    b'[{"message": "syntax error: unexpected EOF"}, {"message": "second"}]'
+)
+
+DATA_PART = (
+    b"Content-Type: application/json\r\n"
+    b"X-Hugr-Path: data.foo\r\n"
+    b"X-Hugr-Part-Type: data\r\n"
+    b"X-Hugr-Format: object\r\n"
+    b"\r\n"
+    b'{"foo": 1}'
+)
+
+
+def test_errors_only_raises():
+    try:
+        HugrIPCResponse(_multipart(ERRORS_PART))
+    except ValueError as e:
+        assert "syntax error" in str(e), str(e)
+        return
+    raise AssertionError("errors-only response did not raise")
+
+
+def test_partial_keeps_data_and_exposes_errors():
+    r = HugrIPCResponse(_multipart(DATA_PART, ERRORS_PART))
+    assert isinstance(r.errors, list), type(r.errors)
+    assert len(r.errors) == 2, r.errors          # the JSON array was flattened
+    assert r.errors[0]["message"].startswith("syntax error")
+    assert "data.foo" in r.parts                 # data survived
+    raised = False
+    try:
+        r.raise_for_errors()
+    except ValueError:
+        raised = True
+    assert raised, "raise_for_errors did not raise on a partial-error response"
+
+
+def test_clean_response_has_empty_errors():
+    r = HugrIPCResponse(_multipart(DATA_PART))
+    assert r.errors == []
+    assert "data.foo" in r.parts
+
+
+if __name__ == "__main__":
+    test_errors_only_raises()
+    test_partial_keeps_data_and_exposes_errors()
+    test_clean_response_has_empty_errors()
+    print("OK: all error-part tests passed")


### PR DESCRIPTION
## Problem

A malformed / errored GraphQL query came back as an **empty result with no exception** — `client.query()` returned a `HugrIPCResponse` whose `.parts == {}` and raised nothing. Callers (e.g. the hugen `build_report` task) then debugged a "fetch bug" that was really a bad query.

Root cause is a client/server header mismatch:
- **Server** (`query-engine` `writeErrorsToIPC`) emits GraphQL errors as a dedicated multipart part: `X-Hugr-Part-Type: "errors"` (plural), `X-Hugr-Format: "object"`, body = JSON array (`gqlerror.List`).
- **Client** `_parse_multipart` only handled the **singular** `"error"`, so the `"errors"` part matched no branch → silently skipped. The singular check was effectively dead code (the server only ever sends `"errors"`).

## Fix

- `_parse_multipart`: match `"errors"` (and keep `"error"`); collect the JSON **array** into a flat error list rather than raising mid-parse, so a partial-success response keeps its data parts.
- `HugrIPCResponse.errors` property + `raise_for_errors()` — the error accessor.
- `__init__` raises `ValueError` on an **errors-only** response (pure GraphQL error → fail loud); a partial response (data + errors) is returned with `.errors` populated.
- Bump `0.3.0` → `0.3.1`.
- `test_ipc_errors.py`: errors-only raises; partial keeps data + flat `.errors` list; clean response → `[]`. All green locally.

Tag `v0.3.1` after merge triggers the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)