### PR TITLE
fix(client): env (HUGR_URL/HUGR_TOKEN) takes precedence over connections.json

### DIFF
--- a/hugr/__init__.py
+++ b/hugr/__init__.py
@@ -35,4 +35,4 @@ __all__ = [
     "new_stream_connection",
 ]
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/hugr/client.py
+++ b/hugr/client.py
@@ -800,41 +800,46 @@ class HugrClient:
         )
         self._tls_skip_verify = tls_skip_verify
 
-        # Priority 1: named connection from connections.json
+        # Priority 1: a connection passed explicitly always wins.
         if connection is not None:
             self._apply_connection(connection if isinstance(connection, str) else None,
                                    connection if isinstance(connection, dict) else None,
                                    url, api_key, api_key_header, token, role, tls_skip_verify)
         else:
-            # Priority 2: default connection from connections.json
-            if not url:
-                try:
-                    from .connections import get_connection
-                    conn = get_connection()
-                    self._apply_connection(None, conn, url, api_key, api_key_header, token, role, tls_skip_verify)
-                    return
-                except (ValueError, FileNotFoundError):
-                    pass
-            # Priority 3: env vars
+            # Priority 2: explicit url= arg, or HUGR_URL / HUGR_TOKEN env.
+            # Inside a headless runtime (e.g. hugen injects HUGR_URL +
+            # HUGR_TOKEN per call) these MUST take precedence over any
+            # ~/.hugr/connections.json that happens to exist on the host —
+            # otherwise a stale default connection shadows the injected
+            # credentials and every call 401s.
             if not url:
                 url = os.environ.get("HUGR_URL")
-            if not url:
+            if url:
+                if not api_key and not token:
+                    api_key = os.environ.get("HUGR_API_KEY")
+                    token = os.environ.get("HUGR_TOKEN")
+                self._url = url
+                self._api_key = api_key
+                self._token = token
+                self._role = role
+                self._api_key_header = (
+                    api_key_header
+                    or os.environ.get("HUGR_API_KEY_HEADER", "X-Hugr-Api-Key")
+                )
+                self._role_header = os.environ.get("HUGR_ROLE_HEADER", "X-Hugr-Role")
+                return
+            # Priority 3: fall back to the default connection in
+            # ~/.hugr/connections.json (interactive / JupyterLab use).
+            try:
+                from .connections import get_connection
+                conn = get_connection()
+                self._apply_connection(None, conn, url, api_key, api_key_header, token, role, tls_skip_verify)
+                return
+            except (ValueError, FileNotFoundError):
                 raise ValueError(
                     "No URL provided. Set HUGR_URL env, pass url=, "
                     "or configure a connection in ~/.hugr/connections.json"
                 )
-            if not api_key and not token:
-                api_key = os.environ.get("HUGR_API_KEY")
-                token = os.environ.get("HUGR_TOKEN")
-            self._url = url
-            self._api_key = api_key
-            self._token = token
-            self._role = role
-            self._api_key_header = (
-                api_key_header
-                or os.environ.get("HUGR_API_KEY_HEADER", "X-Hugr-Api-Key")
-            )
-            self._role_header = os.environ.get("HUGR_ROLE_HEADER", "X-Hugr-Role")
 
     def _apply_connection(self, name, conn_dict, url, api_key, api_key_header, token, role, tls_skip_verify=False):
         """Apply connection config from connections.json, with explicit args taking priority."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hugr-client"
-version = "0.3.1"
+version = "0.3.2"
 description = "Python client for Hugr Arrow IPC over multipart/mixed"
 authors = [
     { name = "Hugr-lab", email = "gribanov.vladimir@gmail.com" }

--- a/test_connection_precedence.py
+++ b/test_connection_precedence.py
@@ -1,0 +1,64 @@
+"""Precedence: env (HUGR_URL/HUGR_TOKEN) must win over ~/.hugr/connections.json.
+
+Regression for the headless-runtime 401: when a host has a
+connections.json with a default (e.g. a stale browser/OIDC connection),
+HugrClient() used to silently prefer that file over the injected
+HUGR_URL/HUGR_TOKEN env, so every call 401'd. Env must win; the
+connection file is the fallback only when no url/env is provided.
+"""
+import json
+
+from hugr.client import HugrClient
+
+
+def _write_connections(tmp_path):
+    cfg = {
+        "default": "stale",
+        "connections": [
+            {
+                "name": "stale",
+                "url": "http://connfile:9999/ipc",
+                "auth_type": "api_key",
+                "api_key": "stale-key",
+            }
+        ],
+    }
+    p = tmp_path / "connections.json"
+    p.write_text(json.dumps(cfg))
+    return p
+
+
+def test_env_wins_over_connections_file(tmp_path, monkeypatch):
+    """HUGR_URL/HUGR_TOKEN env take precedence over a default connection."""
+    monkeypatch.setenv("HUGR_CONFIG_PATH", str(_write_connections(tmp_path)))
+    monkeypatch.setenv("HUGR_URL", "http://from-env:15004/ipc")
+    monkeypatch.setenv("HUGR_TOKEN", "fresh-jwt")
+    monkeypatch.delenv("HUGR_API_KEY", raising=False)
+
+    c = HugrClient()
+    assert c._url == "http://from-env:15004/ipc"
+    assert c._token == "fresh-jwt"
+    # the stale connection-file credentials must NOT leak in
+    assert c._api_key != "stale-key"
+
+
+def test_connections_file_used_when_no_env(tmp_path, monkeypatch):
+    """With no url/env, fall back to the default connection in the file."""
+    monkeypatch.setenv("HUGR_CONFIG_PATH", str(_write_connections(tmp_path)))
+    monkeypatch.delenv("HUGR_URL", raising=False)
+    monkeypatch.delenv("HUGR_TOKEN", raising=False)
+    monkeypatch.delenv("HUGR_API_KEY", raising=False)
+
+    c = HugrClient()
+    assert c._url == "http://connfile:9999/ipc"
+    assert c._api_key == "stale-key"
+
+
+def test_explicit_url_arg_wins(tmp_path, monkeypatch):
+    """An explicit url= still beats both env and the connection file."""
+    monkeypatch.setenv("HUGR_CONFIG_PATH", str(_write_connections(tmp_path)))
+    monkeypatch.setenv("HUGR_URL", "http://from-env:15004/ipc")
+
+    c = HugrClient(url="http://explicit:1/ipc", token="t")
+    assert c._url == "http://explicit:1/ipc"
+    assert c._token == "t"


### PR DESCRIPTION
## Problem

`HugrClient()` resolved a default connection from `~/.hugr/connections.json` **before** reading `HUGR_URL`/`HUGR_TOKEN` from the env. On a host that has a `connections.json` (e.g. a developer's stale browser/OIDC default), every headless call — where a runtime like **hugen** injects `HUGR_URL` + `HUGR_TOKEN` per call — silently used the stale file connection and **401'd** (`Re-login via connection manager`), never touching the injected credentials.

This contradicts the documented contract: inside a headless runtime the client reads `HUGR_URL`/`HUGR_TOKEN` from the env.

Found via a hugen dogfood: a generated report task using `HugrClient()` 401'd on a machine with a `~/.hugr/connections.json` whose default was a browser/OIDC connection with an expired token.

## Fix

Reorder the no-explicit-connection path:

```
explicit url= arg  →  HUGR_URL / HUGR_TOKEN env  →  connections.json default
```

so injected env credentials win, and the connection file remains the fallback only when neither an arg nor an env URL is present.

## Tests

`test_connection_precedence.py` covers all three:
- env beats the connection file,
- the file is used when env is absent,
- an explicit `url=` beats both.

Bump `0.3.1 → 0.3.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)